### PR TITLE
Add option to wrap lib in `get()` similar to `@motiondeveloper/aefunctions`

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,42 +1,87 @@
 {
   "name": "rollup-plugin-ae-jsx",
   "version": "2.0.0",
-  "lockfileVersion": 1,
+  "lockfileVersion": 3,
   "requires": true,
-  "dependencies": {
-    "estree-walker": {
+  "packages": {
+    "": {
+      "name": "rollup-plugin-ae-jsx",
+      "version": "2.0.0",
+      "license": "MIT",
+      "dependencies": {
+        "estree-walker": "^2.0.1",
+        "magic-string": "^0.25.7"
+      },
+      "devDependencies": {
+        "rollup": "^2.23.0"
+      },
+      "peerDependencies": {
+        "rollup": "^1.20.0 || ^2.0.0",
+        "typescript": "^5.5.4"
+      }
+    },
+    "node_modules/estree-walker": {
       "version": "2.0.1",
       "resolved": "https://registry.npmjs.org/estree-walker/-/estree-walker-2.0.1.tgz",
       "integrity": "sha512-tF0hv+Yi2Ot1cwj9eYHtxC0jB9bmjacjQs6ZBTj82H8JwUywFuc+7E83NWfNMwHXZc11mjfFcVXPe9gEP4B8dg=="
     },
-    "fsevents": {
+    "node_modules/fsevents": {
       "version": "2.1.3",
       "resolved": "https://registry.npmjs.org/fsevents/-/fsevents-2.1.3.tgz",
       "integrity": "sha512-Auw9a4AxqWpa9GUfj370BMPzzyncfBABW8Mab7BGWBYDj4Isgq+cDKtx0i6u9jcX9pQDnswsaaOTgTmA5pEjuQ==",
+      "deprecated": "\"Please update to latest v2.3 or v2.2\"",
       "dev": true,
-      "optional": true
+      "hasInstallScript": true,
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": "^8.16.0 || ^10.6.0 || >=11.0.0"
+      }
     },
-    "magic-string": {
+    "node_modules/magic-string": {
       "version": "0.25.7",
       "resolved": "https://registry.npmjs.org/magic-string/-/magic-string-0.25.7.tgz",
       "integrity": "sha512-4CrMT5DOHTDk4HYDlzmwu4FVCcIYI8gauveasrdCu2IKIFOJ3f0v/8MDGJCDL9oD2ppz/Av1b0Nj345H9M+XIA==",
-      "requires": {
+      "dependencies": {
         "sourcemap-codec": "^1.4.4"
       }
     },
-    "rollup": {
+    "node_modules/rollup": {
       "version": "2.23.1",
       "resolved": "https://registry.npmjs.org/rollup/-/rollup-2.23.1.tgz",
       "integrity": "sha512-Heyl885+lyN/giQwxA8AYT2GY3U+gOlTqVLrMQYno8Z1X9lAOpfXPiKiZCyPc25e9BLJM3Zlh957dpTlO4pa8A==",
       "dev": true,
-      "requires": {
+      "bin": {
+        "rollup": "dist/bin/rollup"
+      },
+      "engines": {
+        "node": ">=10.0.0"
+      },
+      "optionalDependencies": {
         "fsevents": "~2.1.2"
       }
     },
-    "sourcemap-codec": {
+    "node_modules/sourcemap-codec": {
       "version": "1.4.8",
       "resolved": "https://registry.npmjs.org/sourcemap-codec/-/sourcemap-codec-1.4.8.tgz",
-      "integrity": "sha512-9NykojV5Uih4lgo5So5dtw+f0JgJX30KCNI8gwhz2J9A15wD0Ml6tjHKwf6fTSa6fAdVBdZeNOs9eJ71qCk8vA=="
+      "integrity": "sha512-9NykojV5Uih4lgo5So5dtw+f0JgJX30KCNI8gwhz2J9A15wD0Ml6tjHKwf6fTSa6fAdVBdZeNOs9eJ71qCk8vA==",
+      "deprecated": "Please use @jridgewell/sourcemap-codec instead"
+    },
+    "node_modules/typescript": {
+      "version": "5.5.4",
+      "resolved": "https://registry.npmjs.org/typescript/-/typescript-5.5.4.tgz",
+      "integrity": "sha512-Mtq29sKDAEYP7aljRgtPOpTvOfbwRWlS6dPRzwjdE+C0R4brX/GUyhHSecbHMFLNBLcJIPt9nl9yG5TZ1weH+Q==",
+      "license": "Apache-2.0",
+      "peer": true,
+      "bin": {
+        "tsc": "bin/tsc",
+        "tsserver": "bin/tsserver"
+      },
+      "engines": {
+        "node": ">=14.17"
+      }
     }
   }
 }

--- a/package.json
+++ b/package.json
@@ -15,7 +15,8 @@
     "README.md"
   ],
   "peerDependencies": {
-    "rollup": "^1.20.0 || ^2.0.0"
+    "rollup": "^1.20.0 || ^2.0.0",
+    "typescript": "^5.5.4"
   },
   "devDependencies": {
     "rollup": "^2.23.0"
@@ -41,6 +42,7 @@
     "magic-string": "^0.25.7"
   },
   "prettier": {
-    "useTabs": false
+    "useTabs": false,
+    "singleQuote": true
   }
 }

--- a/package.json
+++ b/package.json
@@ -39,5 +39,8 @@
   "dependencies": {
     "estree-walker": "^2.0.1",
     "magic-string": "^0.25.7"
+  },
+  "prettier": {
+    "useTabs": false
   }
 }

--- a/src/index.js
+++ b/src/index.js
@@ -2,6 +2,7 @@ import { walk } from "estree-walker";
 import MagicString from "magic-string";
 
 const whitespace = /\s/;
+
 // these will be removed
 const disallowedNodeTypes = [
   "ExpressionStatement",
@@ -10,13 +11,15 @@ const disallowedNodeTypes = [
   "ExportNamedDeclaration",
 ];
 
-export default function afterEffectsJsx(options = {}) {
+// these will also be removed
+const expressionGlobals = ["thisComp", "thisLayer", "thisProperty"];
+
+export default function afterEffectsJsx(options = { wrap: false }) {
   const exports = [];
   return {
     name: "after-effects-jsx", // this name will show up in warnings and errors
     generateBundle(options = {}, bundle, isWrite) {
-      // format each file
-      // to be ae-jsx
+      // format each file to be ae-jsx
       for (const file in bundle) {
         // Get the string code of the file
         let code = bundle[file].code;
@@ -75,68 +78,102 @@ export default function afterEffectsJsx(options = {}) {
           },
         });
 
-        // Remove non exported nodes and convert
-        // to object property style compatible syntax
-        walk(ast, {
-          enter(node, parent) {
-            Object.defineProperty(node, "parent", {
-              value: parent,
-              enumerable: false,
-              configurable: true,
-            });
+        if (options.wrap) {
+          walk(ast, {
+            enter(node, parent) {
+              Object.defineProperty(node, "parent", {
+                value: parent,
+                enumerable: false,
+                configurable: true,
+              });
 
-            if (node.type === "FunctionDeclaration") {
-              // Deal with functions
-              const functionName = node.id.name;
-              if (!exports.includes(functionName)) {
-                // Remove non-exported functions
-                remove(node.start, node.end);
-              } else {
-                // remove the function keyword
-                magicString.remove(node.start, node.id.start);
-                // add a trailing comma
-                magicString.appendLeft(node.end, ",");
+              if (node.type === "VariableDeclaration") {
+                const variableName = node.declarations.map(
+                  (declaration) => declaration.id.name
+                )[0];
+                if (!expressionGlobals.includes(variableName)) {
+                  // Remove variables that aren't exported
+                  remove(node.start, node.end);
+                }
+                // don't process child nodes
+                this.skip();
+              } else if (disallowedNodeTypes.includes(node.type)) {
+                // Remove every top level node that isn't
+                // a function or variable, as they're not allowed
+                removeStatement(node);
+                this.skip();
               }
-              // don't process child nodes
-              this.skip();
-            } else if (node.type === "VariableDeclaration") {
-              // deal with variables
-              const variableName = node.declarations.map(
-                (declaration) => declaration.id.name
-              )[0];
-              if (!exports.includes(variableName)) {
-                // Remove variables that aren't exported
-                remove(node.start, node.end);
-              } else {
-                const valueStart = node.declarations[0].init.start;
-                const variableName = node.declarations[0].id.name;
-                // remove anything before the variable name
-                // e.g. const, var, let
-                magicString.overwrite(
-                  node.start,
-                  valueStart - 1,
-                  `${variableName}:`
-                );
-                const endsInSemiColon =
-                  magicString.slice(node.end - 1, node.end) === ";";
-                if (endsInSemiColon) {
-                  // replace ; with ,
-                  magicString.overwrite(node.end - 1, node.end, ",");
+            },
+          });
+
+          magicString
+            .prepend("get() {\n")
+            .append(`\nreturn {${exports.join(",\n\t")}}\n}`);
+        } else {
+          // Remove non exported nodes and convert
+          // to object property style compatible syntax
+          walk(ast, {
+            enter(node, parent) {
+              Object.defineProperty(node, "parent", {
+                value: parent,
+                enumerable: false,
+                configurable: true,
+              });
+
+              if (node.type === "FunctionDeclaration") {
+                // Deal with functions
+                const functionName = node.id.name;
+                if (!exports.includes(functionName)) {
+                  // Remove non-exported functions
+                  remove(node.start, node.end);
                 } else {
-                  // or add trailing comma
+                  // remove the function keyword
+                  magicString.remove(node.start, node.id.start);
+                  // add a trailing comma
                   magicString.appendLeft(node.end, ",");
                 }
+                // don't process child nodes
+                this.skip();
+              } else if (node.type === "VariableDeclaration") {
+                // deal with variables
+                const variableName = node.declarations.map(
+                  (declaration) => declaration.id.name
+                )[0];
+                if (!exports.includes(variableName)) {
+                  // Remove variables that aren't exported
+                  remove(node.start, node.end);
+                } else {
+                  const valueStart = node.declarations[0].init.start;
+                  const variableName = node.declarations[0].id.name;
+                  // remove anything before the variable name
+                  // e.g. const, var, let
+                  magicString.overwrite(
+                    node.start,
+                    valueStart - 1,
+                    `${variableName}:`
+                  );
+                  const endsInSemiColon =
+                    magicString.slice(node.end - 1, node.end) === ";";
+                  if (endsInSemiColon) {
+                    // replace ; with ,
+                    magicString.overwrite(node.end - 1, node.end, ",");
+                  } else {
+                    // or add trailing comma
+                    magicString.appendLeft(node.end, ",");
+                  }
+                }
+                // don't process child nodes
+                this.skip();
+              } else if (disallowedNodeTypes.includes(node.type)) {
+                // Remove every top level node that isn't
+                // a function or variable, as they're not allowed
+                removeStatement(node);
+                this.skip();
               }
-              // don't process child nodes
-              this.skip();
-            } else if (disallowedNodeTypes.includes(node.type)) {
-              // Remove every top level node that isn't
-              // a function or variable, as they're not allowed
-              removeStatement(node);
-              this.skip();
-            }
-          },
-        });
+            },
+          });
+        }
+
         // Log exports to the terminal
         console.log(`Exported JSX:`, exports);
         // Sanitize output and wrap in braces

--- a/src/index.js
+++ b/src/index.js
@@ -111,14 +111,12 @@ export default function afterEffectsJsx(options = { wrap: false }) {
             .prepend('function get() {\n')
             .append(`\nreturn {${exports.join(',\n\t')}}\n}`);
 
-          // see extra `format` fn below!
-          
-          // const asString = format(magicString.toString()).replace(
-          //   `function get() {`,
-          //   `get() {`
-          // );
+          const asString = format(magicString.toString()).replace(
+            `function get() {`,
+            `get() {`
+          );
 
-          // magicString = new MagicString(asString);
+          magicString = new MagicString(asString);
         } else {
           // Remove non exported nodes and convert
           // to object property style compatible syntax
@@ -195,7 +193,6 @@ export default function afterEffectsJsx(options = { wrap: false }) {
   };
 }
 
-
 // extra: use ts to format... though currently not a dep of `rollup-plugin-ae-jsx`
 
 // https://github.com/vvakame/typescript-formatter/tree/master/lib
@@ -263,4 +260,3 @@ function format(text, fileName = 'temp.ts', options = defaultOptions) {
 
   return text;
 }
-


### PR DESCRIPTION
In cases where functions in your library reference other values, like:

```js
// example.jsx
{
  someNumber: 5,
  someFunction(inputParamaters) {
    return someNumber;
  },
}
```

You will get a `ReferenceError: someNumber is not defined` expression error. If you attempt to reference via `this.someNumber` you won't get an expression error, but the value resolves to `undefined`.

```js
// textLayer.sourceText expression
const { someFunction } = footage("example.jsx").sourceData;
someFunction(); // typeof someFunction() === undefined
```

You've solved this in your [aefunctions.jsx](https://github.com/motiondeveloper/aefunctions) lib by wrapping all of your libs functions in a single `getFunctions()` method. This PR adds similar functionality to `rollup-plugin-ae-jsx` via a `wrap: true` option. 

Additionally, this PR will format your `.jsx` with TypeScript (seems to do a better job than `MagicString.trim().indent()`) but given that project is written in JavaScript maybe it's not a great idea to introduce TypeScript just for this, haha!