### PR TITLE
Add option to wrap compiled code in `get()` method

### DIFF
--- a/README.md
+++ b/README.md
@@ -25,14 +25,14 @@ npm install rollup-plugin-ae-jsx --save-dev
 Create a `rollup.config.js` [configuration file](https://www.rollupjs.org/guide/en/#configuration-files), import the plugin, and add it to the `plugins` array:
 
 ```js
-import afterEffectJsx from "./rollup-plugin-ae-jsx";
-import pkg from "./package.json";
+import afterEffectJsx from './rollup-plugin-ae-jsx';
+import pkg from './package.json';
 
 export default {
-  input: "src/index.ts",
+  input: 'src/index.ts',
   output: {
-    file: "dist/index.jsx",
-    format: "es",
+    file: 'dist/index.jsx',
+    format: 'es',
   },
   external: Object.keys(pkg.dependencies),
   plugins: [afterEffectJsx()],
@@ -44,12 +44,85 @@ export default {
 
 Then call `rollup` either via the [CLI](https://www.rollupjs.org/guide/en/#command-line-reference) or the [API](https://www.rollupjs.org/guide/en/#javascript-api).
 
-## Proccess
+## Options
+
+### `wrap`
+
+Type: `boolean` \
+Default: `false`
+
+Wraps compiled code in a `get()` function. See [Wrapping](#wrapping) for more detail.
+
+## Process
 
 1. Creating a list of the exported functions and variables from the index file
 2. Removing non-compatible statements: `['ExpressionStatement', 'DebuggerStatement', 'ImportDeclaration', 'ExportNamedDeclaration'];`
 3. Converting function and variable declarations into `.jsx` compliant syntax
 4. Wrapping in braces (`{}`)
+
+## Wrapping
+
+Compiling code that references top level functions or variables will error when run in After Effects, since each exported property is isolated from the surrounding code.
+
+For example the following source code:
+
+```js
+function add(a, b) {
+  return a + b;
+}
+
+function getFour() {
+  return add(2, 2);
+}
+
+export { add, getFour };
+```
+
+Will compile to the following `.jsx` file:
+
+```js
+{
+  add(a, b) {
+    return a + b;
+  },
+  getFour() {
+    return add(2, 2); // error, add is not defined
+  }
+}
+```
+
+Which will error, since `add()` is not defined within the scope of `getFour()`.
+
+This can be solved by wrapping all of your code in a parent function, which `rollup-plugin-jsx` will do for you if `wrap` is set to true.
+
+```js
+// rollup.config.js
+plugins: [afterEffectJsx({ wrap: true })],
+```
+
+The compiled `.jsx` would then be:
+
+```js
+{
+  get() {
+    function add(a, b) {
+      return a + b;
+    }
+
+    function getFour() {
+      return add(2, 2);
+    }
+
+    return { add, getFour }
+  }
+}
+```
+
+You then would need to call `.get()` in your expressions:
+
+```js
+const { getFour, add } = footage('index.jsx').sourceData.get();
+```
 
 ## Meta
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -10,14 +10,13 @@
       "license": "MIT",
       "dependencies": {
         "estree-walker": "^2.0.1",
-        "magic-string": "^0.25.7"
+        "magic-string": "^0.25.9"
       },
       "devDependencies": {
         "rollup": "^2.23.0"
       },
       "peerDependencies": {
-        "rollup": "^1.20.0 || ^2.0.0",
-        "typescript": "^5.5.4"
+        "rollup": "^1.20.0 || ^2.0.0"
       }
     },
     "node_modules/estree-walker": {
@@ -41,11 +40,12 @@
       }
     },
     "node_modules/magic-string": {
-      "version": "0.25.7",
-      "resolved": "https://registry.npmjs.org/magic-string/-/magic-string-0.25.7.tgz",
-      "integrity": "sha512-4CrMT5DOHTDk4HYDlzmwu4FVCcIYI8gauveasrdCu2IKIFOJ3f0v/8MDGJCDL9oD2ppz/Av1b0Nj345H9M+XIA==",
+      "version": "0.25.9",
+      "resolved": "https://registry.npmjs.org/magic-string/-/magic-string-0.25.9.tgz",
+      "integrity": "sha512-RmF0AsMzgt25qzqqLc1+MbHmhdx0ojF2Fvs4XnOqz2ZOBXzzkEwc/dJQZCYHAn7v1jbVOjAZfK8msRn4BxO4VQ==",
+      "license": "MIT",
       "dependencies": {
-        "sourcemap-codec": "^1.4.4"
+        "sourcemap-codec": "^1.4.8"
       }
     },
     "node_modules/rollup": {
@@ -68,20 +68,6 @@
       "resolved": "https://registry.npmjs.org/sourcemap-codec/-/sourcemap-codec-1.4.8.tgz",
       "integrity": "sha512-9NykojV5Uih4lgo5So5dtw+f0JgJX30KCNI8gwhz2J9A15wD0Ml6tjHKwf6fTSa6fAdVBdZeNOs9eJ71qCk8vA==",
       "deprecated": "Please use @jridgewell/sourcemap-codec instead"
-    },
-    "node_modules/typescript": {
-      "version": "5.5.4",
-      "resolved": "https://registry.npmjs.org/typescript/-/typescript-5.5.4.tgz",
-      "integrity": "sha512-Mtq29sKDAEYP7aljRgtPOpTvOfbwRWlS6dPRzwjdE+C0R4brX/GUyhHSecbHMFLNBLcJIPt9nl9yG5TZ1weH+Q==",
-      "license": "Apache-2.0",
-      "peer": true,
-      "bin": {
-        "tsc": "bin/tsc",
-        "tsserver": "bin/tsserver"
-      },
-      "engines": {
-        "node": ">=14.17"
-      }
     }
   }
 }

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,42 +1,87 @@
 {
   "name": "rollup-plugin-ae-jsx",
   "version": "2.0.0",
-  "lockfileVersion": 1,
+  "lockfileVersion": 3,
   "requires": true,
-  "dependencies": {
-    "estree-walker": {
+  "packages": {
+    "": {
+      "name": "rollup-plugin-ae-jsx",
+      "version": "2.0.0",
+      "license": "MIT",
+      "dependencies": {
+        "estree-walker": "^2.0.1",
+        "magic-string": "^0.25.7"
+      },
+      "devDependencies": {
+        "rollup": "^2.23.0"
+      },
+      "peerDependencies": {
+        "rollup": "^1.20.0 || ^2.0.0",
+        "typescript": "^5.5.4"
+      }
+    },
+    "node_modules/estree-walker": {
       "version": "2.0.1",
       "resolved": "https://registry.npmjs.org/estree-walker/-/estree-walker-2.0.1.tgz",
       "integrity": "sha512-tF0hv+Yi2Ot1cwj9eYHtxC0jB9bmjacjQs6ZBTj82H8JwUywFuc+7E83NWfNMwHXZc11mjfFcVXPe9gEP4B8dg=="
     },
-    "fsevents": {
+    "node_modules/fsevents": {
       "version": "2.1.3",
       "resolved": "https://registry.npmjs.org/fsevents/-/fsevents-2.1.3.tgz",
       "integrity": "sha512-Auw9a4AxqWpa9GUfj370BMPzzyncfBABW8Mab7BGWBYDj4Isgq+cDKtx0i6u9jcX9pQDnswsaaOTgTmA5pEjuQ==",
+      "deprecated": "\"Please update to latest v2.3 or v2.2\"",
       "dev": true,
-      "optional": true
+      "hasInstallScript": true,
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": "^8.16.0 || ^10.6.0 || >=11.0.0"
+      }
     },
-    "magic-string": {
+    "node_modules/magic-string": {
       "version": "0.25.7",
       "resolved": "https://registry.npmjs.org/magic-string/-/magic-string-0.25.7.tgz",
       "integrity": "sha512-4CrMT5DOHTDk4HYDlzmwu4FVCcIYI8gauveasrdCu2IKIFOJ3f0v/8MDGJCDL9oD2ppz/Av1b0Nj345H9M+XIA==",
-      "requires": {
+      "dependencies": {
         "sourcemap-codec": "^1.4.4"
       }
     },
-    "rollup": {
+    "node_modules/rollup": {
       "version": "2.23.1",
       "resolved": "https://registry.npmjs.org/rollup/-/rollup-2.23.1.tgz",
       "integrity": "sha512-Heyl885+lyN/giQwxA8AYT2GY3U+gOlTqVLrMQYno8Z1X9lAOpfXPiKiZCyPc25e9BLJM3Zlh957dpTlO4pa8A==",
       "dev": true,
-      "requires": {
+      "bin": {
+        "rollup": "dist/bin/rollup"
+      },
+      "engines": {
+        "node": ">=10.0.0"
+      },
+      "optionalDependencies": {
         "fsevents": "~2.1.2"
       }
     },
-    "sourcemap-codec": {
+    "node_modules/sourcemap-codec": {
       "version": "1.4.8",
       "resolved": "https://registry.npmjs.org/sourcemap-codec/-/sourcemap-codec-1.4.8.tgz",
-      "integrity": "sha512-9NykojV5Uih4lgo5So5dtw+f0JgJX30KCNI8gwhz2J9A15wD0Ml6tjHKwf6fTSa6fAdVBdZeNOs9eJ71qCk8vA=="
+      "integrity": "sha512-9NykojV5Uih4lgo5So5dtw+f0JgJX30KCNI8gwhz2J9A15wD0Ml6tjHKwf6fTSa6fAdVBdZeNOs9eJ71qCk8vA==",
+      "deprecated": "Please use @jridgewell/sourcemap-codec instead"
+    },
+    "node_modules/typescript": {
+      "version": "5.5.4",
+      "resolved": "https://registry.npmjs.org/typescript/-/typescript-5.5.4.tgz",
+      "integrity": "sha512-Mtq29sKDAEYP7aljRgtPOpTvOfbwRWlS6dPRzwjdE+C0R4brX/GUyhHSecbHMFLNBLcJIPt9nl9yG5TZ1weH+Q==",
+      "license": "Apache-2.0",
+      "peer": true,
+      "bin": {
+        "tsc": "bin/tsc",
+        "tsserver": "bin/tsserver"
+      },
+      "engines": {
+        "node": ">=14.17"
+      }
     }
   }
 }

--- a/package.json
+++ b/package.json
@@ -15,7 +15,8 @@
     "README.md"
   ],
   "peerDependencies": {
-    "rollup": "^1.20.0 || ^2.0.0"
+    "rollup": "^1.20.0 || ^2.0.0",
+    "typescript": "^5.5.4"
   },
   "devDependencies": {
     "rollup": "^2.23.0"
@@ -41,6 +42,7 @@
     "magic-string": "^0.25.7"
   },
   "prettier": {
-    "useTabs": false
+    "useTabs": false,
+    "singleQuote": true
   }
 }

--- a/package.json
+++ b/package.json
@@ -38,7 +38,7 @@
   "homepage": "https://github.com/motiondeveloper/rollup-plugin-ae-jsx#readme",
   "dependencies": {
     "estree-walker": "^2.0.1",
-    "magic-string": "^0.25.7"
+    "magic-string": "^0.25.9"
   },
   "prettier": {
     "useTabs": false,

--- a/package.json
+++ b/package.json
@@ -15,8 +15,7 @@
     "README.md"
   ],
   "peerDependencies": {
-    "rollup": "^1.20.0 || ^2.0.0",
-    "typescript": "^5.5.4"
+    "rollup": "^1.20.0 || ^2.0.0"
   },
   "devDependencies": {
     "rollup": "^2.23.0"

--- a/package.json
+++ b/package.json
@@ -39,5 +39,8 @@
   "dependencies": {
     "estree-walker": "^2.0.1",
     "magic-string": "^0.25.7"
+  },
+  "prettier": {
+    "useTabs": false
   }
 }

--- a/src/index.js
+++ b/src/index.js
@@ -107,15 +107,10 @@ export default function afterEffectsJsx(options = { wrap: false }) {
             },
           });
 
+          // wrap entire code in get() method
           magicString
-            .prepend('function get() {\n')
+            .prepend('get() {\n')
             .append(`\nreturn {${exports.join(',\n\t')}}\n}`);
-
-          const asString = magicString
-            .toString()
-            .replace(`function get() {`, `get() {`);
-
-          magicString = new MagicString(asString);
         } else {
           // Remove non exported nodes and convert
           // to object property style compatible syntax

--- a/src/index.js
+++ b/src/index.js
@@ -111,10 +111,14 @@ export default function afterEffectsJsx(options = { wrap: false }) {
             },
           });
 
-          // wrap entire code in get() method
           magicString
+            // add return statements for exports
+            .append(`\nreturn { ${exports.join(', ')} }`)
+            // indent everything before wrapping
+            .indent()
+            // wrap entire code in get() method
             .prepend('get() {\n')
-            .append(`\nreturn {${exports.join(',\n\t')}}\n}`);
+            .append('\n}');
         } else {
           // Remove non exported nodes and convert
           // to object property style compatible syntax
@@ -183,7 +187,7 @@ export default function afterEffectsJsx(options = { wrap: false }) {
         // Log exports to the terminal
         console.log(`Exported JSX:`, exports);
         // Sanitize output and wrap in braces
-        magicString.trim().prepend('{\n').append('\n}').indent().trimStart();
+        magicString.trim().indent().prepend('{\n').append('\n}').trimStart();
         // Replace the files code with modified
         bundle[file].code = magicString.toString();
       }

--- a/src/index.js
+++ b/src/index.js
@@ -2,6 +2,7 @@ import { walk } from "estree-walker";
 import MagicString from "magic-string";
 
 const whitespace = /\s/;
+
 // these will be removed
 const disallowedNodeTypes = [
   "ExpressionStatement",
@@ -10,13 +11,15 @@ const disallowedNodeTypes = [
   "ExportNamedDeclaration",
 ];
 
-export default function afterEffectsJsx(options = {}) {
+// these will also be removed
+const expressionGlobals = ["thisComp", "thisLayer", "thisProperty"];
+
+export default function afterEffectsJsx(options = { wrap: false }) {
   const exports = [];
   return {
     name: "after-effects-jsx", // this name will show up in warnings and errors
     generateBundle(options = {}, bundle, isWrite) {
-      // format each file
-      // to be ae-jsx
+      // format each file to be ae-jsx
       for (const file in bundle) {
         // Get the string code of the file
         let code = bundle[file].code;
@@ -75,68 +78,102 @@ export default function afterEffectsJsx(options = {}) {
           },
         });
 
-        // Remove non exported nodes and convert
-        // to object property style compatible syntax
-        walk(ast, {
-          enter(node, parent) {
-            Object.defineProperty(node, "parent", {
-              value: parent,
-              enumerable: false,
-              configurable: true,
-            });
+        if (options.wrap) {
+          walk(ast, {
+            enter(node, parent) {
+              Object.defineProperty(node, "parent", {
+                value: parent,
+                enumerable: false,
+                configurable: true,
+              });
 
-            if (node.type === "FunctionDeclaration") {
-              // Deal with functions
-              const functionName = node.id.name;
-              if (!exports.includes(functionName)) {
-                // Remove non-exported functions
-                remove(node.start, node.end);
-              } else {
-                // remove the function keyword
-                magicString.remove(node.start, node.id.start);
-                // add a trailing comma
-                magicString.appendLeft(node.end, ",");
+              if (node.type === "VariableDeclaration") {
+                const variableName = node.declarations.map(
+                  (declaration) => declaration.id.name
+                )[0];
+                if (!expressionGlobals.includes(variableName)) {
+                  // Remove variables that aren't exported
+                  remove(node.start, node.end);
+                }
+                // don't process child nodes
+                this.skip();
+              } else if (disallowedNodeTypes.includes(node.type)) {
+                // Remove every top level node that isn't
+                // a function or variable, as they're not allowed
+                removeStatement(node);
+                this.skip();
               }
-              // don't process child nodes
-              this.skip();
-            } else if (node.type === "VariableDeclaration") {
-              // deal with variables
-              const variableName = node.declarations.map(
-                (declaration) => declaration.id.name
-              )[0];
-              if (!exports.includes(variableName)) {
-                // Remove variables that aren't exported
-                remove(node.start, node.end);
-              } else {
-                const valueStart = node.declarations[0].init.start;
-                const variableName = node.declarations[0].id.name;
-                // remove anything before the variable name
-                // e.g. const, var, let
-                magicString.overwrite(
-                  node.start,
-                  valueStart - 1,
-                  `${variableName}:`
-                );
-                const endsInSemiColon =
-                  magicString.slice(node.end - 1, node.end) === ";";
-                if (endsInSemiColon) {
-                  // replace ; with ,
-                  magicString.overwrite(node.end - 1, node.end, ",");
+            },
+          });
+
+          magicString
+            .prepend("get() {\n")
+            .append(`\nreturn {${exports.join(",\n\t")}}\n}`);
+        } else {
+          // Remove non exported nodes and convert
+          // to object property style compatible syntax
+          walk(ast, {
+            enter(node, parent) {
+              Object.defineProperty(node, "parent", {
+                value: parent,
+                enumerable: false,
+                configurable: true,
+              });
+
+              if (node.type === "FunctionDeclaration") {
+                // Deal with functions
+                const functionName = node.id.name;
+                if (!exports.includes(functionName)) {
+                  // Remove non-exported functions
+                  remove(node.start, node.end);
                 } else {
-                  // or add trailing comma
+                  // remove the function keyword
+                  magicString.remove(node.start, node.id.start);
+                  // add a trailing comma
                   magicString.appendLeft(node.end, ",");
                 }
+                // don't process child nodes
+                this.skip();
+              } else if (node.type === "VariableDeclaration") {
+                // deal with variables
+                const variableName = node.declarations.map(
+                  (declaration) => declaration.id.name
+                )[0];
+                if (!exports.includes(variableName)) {
+                  // Remove variables that aren't exported
+                  remove(node.start, node.end);
+                } else {
+                  const valueStart = node.declarations[0].init.start;
+                  const variableName = node.declarations[0].id.name;
+                  // remove anything before the variable name
+                  // e.g. const, var, let
+                  magicString.overwrite(
+                    node.start,
+                    valueStart - 1,
+                    `${variableName}:`
+                  );
+                  const endsInSemiColon =
+                    magicString.slice(node.end - 1, node.end) === ";";
+                  if (endsInSemiColon) {
+                    // replace ; with ,
+                    magicString.overwrite(node.end - 1, node.end, ",");
+                  } else {
+                    // or add trailing comma
+                    magicString.appendLeft(node.end, ",");
+                  }
+                }
+                // don't process child nodes
+                this.skip();
+              } else if (disallowedNodeTypes.includes(node.type)) {
+                // Remove every top level node that isn't
+                // a function or variable, as they're not allowed
+                removeStatement(node);
+                this.skip();
               }
-              // don't process child nodes
-              this.skip();
-            } else if (disallowedNodeTypes.includes(node.type)) {
-              // Remove every top level node that isn't
-              // a function or variable, as they're not allowed
-              removeStatement(node);
-              this.skip();
-            }
-          },
-        });
+            },
+          });
+        }
+
         // Log exports to the terminal
         console.log(`Exported JSX:`, exports);
         // Sanitize output and wrap in braces

--- a/src/index.js
+++ b/src/index.js
@@ -111,10 +111,9 @@ export default function afterEffectsJsx(options = { wrap: false }) {
             .prepend('function get() {\n')
             .append(`\nreturn {${exports.join(',\n\t')}}\n}`);
 
-          const asString = format(magicString.toString()).replace(
-            `function get() {`,
-            `get() {`
-          );
+          const asString = magicString
+            .toString()
+            .replace(`function get() {`, `get() {`);
 
           magicString = new MagicString(asString);
         } else {
@@ -191,72 +190,4 @@ export default function afterEffectsJsx(options = { wrap: false }) {
       }
     },
   };
-}
-
-// extra: use ts to format... though currently not a dep of `rollup-plugin-ae-jsx`
-
-// https://github.com/vvakame/typescript-formatter/tree/master/lib
-import * as ts from 'typescript';
-
-const defaultOptions = {
-  baseIndentSize: 0,
-  indentSize: 2,
-  tabSize: 2,
-  indentStyle: ts.IndentStyle.Smart,
-  newLineCharacter: '\r\n',
-  convertTabsToSpaces: true,
-  insertSpaceAfterCommaDelimiter: true,
-  insertSpaceAfterSemicolonInForStatements: true,
-  insertSpaceBeforeAndAfterBinaryOperators: true,
-  insertSpaceAfterConstructor: false,
-  insertSpaceAfterKeywordsInControlFlowStatements: true,
-  insertSpaceAfterFunctionKeywordForAnonymousFunctions: false,
-  insertSpaceAfterOpeningAndBeforeClosingNonemptyParenthesis: false,
-  insertSpaceAfterOpeningAndBeforeClosingNonemptyBrackets: false,
-  insertSpaceAfterOpeningAndBeforeClosingNonemptyBraces: true,
-  insertSpaceAfterOpeningAndBeforeClosingTemplateStringBraces: false,
-  insertSpaceAfterOpeningAndBeforeClosingJsxExpressionBraces: false,
-  insertSpaceAfterTypeAssertion: false,
-  insertSpaceBeforeFunctionParenthesis: false,
-  placeOpenBraceOnNewLineForFunctions: false,
-  placeOpenBraceOnNewLineForControlBlocks: false,
-  insertSpaceBeforeTypeAnnotation: false,
-};
-
-class LanguageServiceHost {
-  constructor() {
-    this.files = {};
-    // for ts.LanguageServiceHost
-    this.getCompilationSettings = () => ts.getDefaultCompilerOptions();
-    this.getScriptFileNames = () => Object.keys(this.files);
-    this.getScriptVersion = (_fileName) => '0';
-    this.getScriptSnapshot = (fileName) => this.files[fileName];
-    this.getCurrentDirectory = () => process.cwd();
-    this.getDefaultLibFileName = (options) => ts.getDefaultLibFilePath(options);
-  }
-  addFile(fileName, text) {
-    this.files[fileName] = ts.ScriptSnapshot.fromString(text);
-  }
-}
-
-function format(text, fileName = 'temp.ts', options = defaultOptions) {
-  const host = new LanguageServiceHost();
-  host.addFile(fileName, text);
-
-  const languageService = ts.createLanguageService(host);
-  const edits = languageService.getFormattingEditsForDocument(
-    fileName,
-    options
-  );
-
-  edits
-    .sort((a, b) => a.span.start - b.span.start)
-    .reverse()
-    .forEach((edit) => {
-      const head = text.slice(0, edit.span.start);
-      const tail = text.slice(edit.span.start + edit.span.length);
-      text = `${head}${edit.newText}${tail}`;
-    });
-
-  return text;
 }

--- a/src/index.js
+++ b/src/index.js
@@ -111,14 +111,12 @@ export default function afterEffectsJsx(options = { wrap: false }) {
             .prepend('function get() {\n')
             .append(`\nreturn {${exports.join(',\n\t')}}\n}`);
 
-          // see extra `format` fn below!
-          
-          // const asString = format(magicString.toString()).replace(
-          //   `function get() {`,
-          //   `get() {`
-          // );
+          const asString = format(magicString.toString()).replace(
+            `function get() {`,
+            `get() {`
+          );
 
-          // magicString = new MagicString(asString);
+          magicString = new MagicString(asString);
         } else {
           // Remove non exported nodes and convert
           // to object property style compatible syntax
@@ -195,7 +193,6 @@ export default function afterEffectsJsx(options = { wrap: false }) {
   };
 }
 
-
 // extra: use ts to format... though currently not a dep of `rollup-plugin-ae-jsx`
 
 // https://github.com/vvakame/typescript-formatter/tree/master/lib
@@ -263,4 +260,3 @@ function format(text, fileName = 'temp.ts', options = defaultOptions) {
 
   return text;
 }
-

--- a/src/index.js
+++ b/src/index.js
@@ -80,6 +80,9 @@ export default function afterEffectsJsx(options = { wrap: false }) {
         });
 
         if (wrap) {
+          // Remove expression globals and unsupported code
+          // then wrap in get() method. Less work is needed in this case
+          // everything is wrapped in a single function
           walk(ast, {
             enter(node, parent) {
               Object.defineProperty(node, 'parent', {
@@ -92,8 +95,9 @@ export default function afterEffectsJsx(options = { wrap: false }) {
                 const variableName = node.declarations.map(
                   (declaration) => declaration.id.name
                 )[0];
+
                 if (expressionGlobals.includes(variableName)) {
-                  // Remove variables that aren't exported
+                  // Remove temporary expression global declarations
                   remove(node.start, node.end);
                 }
                 // don't process child nodes


### PR DESCRIPTION
@fartinmartin I made a few slight changes, mainly removing the typescript based formatting.

I think formatting is probably better handled in the rollup config file of users of this, so they can decide if/how they want to format the output, minify it, obfuscate it etc. Makes sense to limit the scope of this package to compiling to a `jsx` compatible output in my opinion.

Let me know what you think! Appreciate your work on this.